### PR TITLE
add cython module to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
 from setuptools import setup, find_packages
+from setuptools.extension import Extension
+from Cython.Build import cythonize
 
 import ClearMap
 
@@ -9,6 +11,12 @@ with open('README.rst') as fptr:
 
 with open('LICENSE.txt') as fptr:
     license = fptr.read()
+
+extensions = [Extension(
+        "ClearMap/Analysis/VoxelizationCode",
+        ["ClearMap/Analysis/VoxelizationCode.pyx"],
+    )
+]
 
 setup(
     name             = ClearMap.__title__,
@@ -20,6 +28,7 @@ setup(
     url              = 'https://www.idisco.info/',
     license          = license,
     packages         = find_packages(exclude=('tests', 'docs')),
+    ext_modules      = cythonize(extensions),
     classifiers=(
         'Development Status :: 1- Beta',
         'Intended Audience :: Science/Research',


### PR DESCRIPTION
Hello,

Here is a small fix to install cython module alongside others, e.g. when using `pip install --user .` in the repository folder. Otherwise `VoxelizationCode.pyx` is not compiled and installed.